### PR TITLE
Point parametric

### DIFF
--- a/dist/parser.d.ts
+++ b/dist/parser.d.ts
@@ -24,6 +24,19 @@ export declare type ParsedEquation1D = {
     calcType: 'x' | 'y' | 'fx' | 'fy';
     warn?: string;
 };
+export declare type ParsedPoint = {
+    type: 'point';
+    key: string;
+    x: number;
+    y: number;
+};
+export declare type ParsedParametric = {
+    type: 'parametric';
+    key: string;
+    x: ValueFunction1D;
+    y: ValueFunction1D;
+    warn?: string;
+};
 export declare type ParsedEquation = ParsedEquation1D | ParsedEquation2D;
 export declare type ParsedBlank = {
     type: 'blank';
@@ -36,6 +49,6 @@ export declare type ParsedError = {
     type: 'error';
     error: string;
 };
-export declare type ParsedFormula = ParsedEquation | ParsedDefinition | ParsedError | ParsedBlank;
+export declare type ParsedFormula = ParsedEquation | ParsedDefinition | ParsedError | ParsedBlank | ParsedPoint | ParsedParametric;
 export declare function parseFormulas(expressions: string[]): ParsedFormula[];
 export {};

--- a/dist/renderer.d.ts
+++ b/dist/renderer.d.ts
@@ -1,4 +1,4 @@
-import { ParsedEquation1D, ParsedEquation2D } from './parser';
+import { ParsedEquation1D, ParsedEquation2D, ParsedParametric } from './parser';
 declare type RenderingRange = {
     xMin: number;
     xMax: number;
@@ -20,6 +20,19 @@ export declare type CalcResult1D = RangeResult1D | CurveResult;
 export declare function calc1DRange(formula: ParsedEquation1D, size: number, min: number, max: number): RangeResult1D;
 export declare function calc1DCurves(formula: ParsedEquation1D, size: number, min: number, max: number): CurveResult;
 export declare function render1D(canvas: HTMLCanvasElement, size: number, offset: number, range: RenderingRange, formula: ParsedEquation1D, result: RangeResult1D | CurveResult, renderMode: {
+    color: string;
+    lineWidth: number;
+    fillAlpha: number;
+}): void;
+export declare function renderParametric(canvas: HTMLCanvasElement, size: number, offset: number, range: RenderingRange, formula: ParsedParametric, renderMode: {
+    color: string;
+    lineWidth: number;
+    fillAlpha: number;
+}): void;
+export declare function renderPoint(canvas: HTMLCanvasElement, size: number, offset: number, range: RenderingRange, point: {
+    x: number;
+    y: number;
+}, renderMode: {
     color: string;
     lineWidth: number;
     fillAlpha: number;

--- a/dist/renderer.js
+++ b/dist/renderer.js
@@ -1,6 +1,6 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.render1D = exports.calc1DCurves = exports.calc1DRange = exports.render2D = void 0;
+exports.renderPoint = exports.renderParametric = exports.render1D = exports.calc1DCurves = exports.calc1DRange = exports.render2D = void 0;
 const numcore_1 = require("numcore");
 function fillModeToMask(fillMode) {
     return ((fillMode.positive ? (1 << numcore_1.RangeResults.POSITIVE) : 0) +
@@ -353,3 +353,48 @@ function render1D(canvas, size, offset, range, formula, result, renderMode) {
     ctx.restore();
 }
 exports.render1D = render1D;
+function renderParametric(canvas, size, offset, range, formula, renderMode) {
+    const xFactor = size / (range.xMax - range.xMin);
+    const xOffset = offset - size * range.xMin / (range.xMax - range.xMin);
+    const yFactor = size / (range.yMax - range.yMin);
+    const yOffset = offset - size * range.yMin / (range.yMax - range.yMin);
+    const ctx = canvas.getContext('2d');
+    ctx.save();
+    ctx.beginPath();
+    const N = 512;
+    ctx.rect(0, 0, size, size);
+    ctx.clip();
+    ctx.globalAlpha = 1;
+    ctx.strokeStyle = renderMode.color;
+    ctx.lineWidth = renderMode.lineWidth;
+    ctx.beginPath();
+    ctx.moveTo(xOffset + xFactor * formula.x(0), yOffset + yFactor * formula.y(0));
+    for (let i = 1; i <= N; i++) {
+        const t = i / N;
+        ctx.lineTo(xOffset + xFactor * formula.x(t), yOffset + yFactor * formula.y(t));
+    }
+    ctx.stroke();
+    ctx.restore();
+}
+exports.renderParametric = renderParametric;
+function renderPoint(canvas, size, offset, range, point, renderMode) {
+    const xFactor = size / (range.xMax - range.xMin);
+    const xOffset = offset - size * range.xMin / (range.xMax - range.xMin);
+    const yFactor = size / (range.yMax - range.yMin);
+    const yOffset = offset - size * range.yMin / (range.yMax - range.yMin);
+    const ctx = canvas.getContext('2d');
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, size, size);
+    ctx.clip();
+    ctx.fillStyle = ctx.strokeStyle = renderMode.color;
+    ctx.globalAlpha = renderMode.fillAlpha;
+    ctx.beginPath();
+    ctx.arc(xOffset + xFactor * point.x, yOffset + yFactor * point.y, renderMode.lineWidth * 2, 0, 2 * Math.PI);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+    ctx.lineWidth = renderMode.lineWidth;
+    ctx.stroke();
+    ctx.restore();
+}
+exports.renderPoint = renderPoint;

--- a/dist/view.d.ts
+++ b/dist/view.d.ts
@@ -1,4 +1,4 @@
-import { ParsedFormula, ParsedEquation, ParsedEquation1D } from './parser';
+import { ParsedFormula, ParsedEquation, ParsedPoint, ParsedParametric, ParsedEquation1D } from './parser';
 import { CalcResult1D } from './renderer';
 export declare type Size = {
     width: number;
@@ -52,7 +52,7 @@ declare type Panel = {
     ix: number;
     iy: number;
 };
-declare type RenderKey = [string, number, ParsedEquation];
+declare type RenderKey = [string, number, ParsedEquation | ParsedPoint | ParsedParametric];
 export declare class View {
     canvas: HTMLCanvasElement;
     width: number;

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,16 +1,16 @@
-import { View } from 'xyview'
+import { View, FormulaInput } from 'xyview'
 
 onload = () => {
-  const formulas = [
+  const formulas: FormulaInput[] = [
     { tex: 'x^4+y^4=1+\\frac{\\sin4\\theta}{2}', color: 'blue', fillAlpha: 0.5 },
     { plain: '(x*x+y*y-1+sin(5theta)/3)*(y-tan(4x-siny))*floor(x)>=0√(y+1-xx)', color: 'red', fillAlpha: 0.5 },
-    { plain: '', color: 'cyan' },
+    { plain: '(cost/2+sin5t/4+abs(cos7t)/8, sint/2+sin3t/4+abs(cos12t)/8)', color: 'cyan', tRange: [-Math.PI, Math.PI] },
     { plain: '', color: 'magenta' },
     { plain: '', color: 'yellow' },
   ]
   const view = new View({
     size: { width: 512, height: 512 },
-    formulas: [...formulas]
+    formulas: [...formulas],
   })
   document.body.append(view.canvas)
 
@@ -35,7 +35,7 @@ onload = () => {
   })
   function update() {
     view.update({ formulas })
-    for (const { input, index, message } of forms) {
+    for (const { index, message } of forms) {
       const parsed = view.formulas[index].parsed
       const error = 'error' in parsed ? parsed.error : undefined
       const warn = 'warn' in parsed ? parsed.warn : undefined

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -17,7 +17,7 @@
     "..": {
       "version": "0.0.0",
       "dependencies": {
-        "numcore": "https://github.com/tompng/numcore.git"
+        "numcore": "../numcore"
       },
       "devDependencies": {
         "typescript": "*"
@@ -2745,7 +2745,7 @@
     "xyview": {
       "version": "file:..",
       "requires": {
-        "numcore": "https://github.com/tompng/numcore.git",
+        "numcore": "../numcore",
         "typescript": "*"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,21 @@
       "name": "xyview",
       "version": "0.0.0",
       "dependencies": {
-        "numcore": "https://github.com/tompng/numcore.git"
+        "numcore": "../numcore"
       },
       "devDependencies": {
         "typescript": "*"
       }
     },
-    "node_modules/numcore": {
+    "../numcore": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/tompng/numcore.git#6d1453a01871be41a6eb0ec5c131a189bbe377a7"
+      "devDependencies": {
+        "typescript": "*"
+      }
+    },
+    "node_modules/numcore": {
+      "resolved": "../numcore",
+      "link": true
     },
     "node_modules/typescript": {
       "version": "4.6.4",
@@ -33,8 +39,10 @@
   },
   "dependencies": {
     "numcore": {
-      "version": "git+ssh://git@github.com/tompng/numcore.git#6d1453a01871be41a6eb0ec5c131a189bbe377a7",
-      "from": "numcore@https://github.com/tompng/numcore.git"
+      "version": "file:../numcore",
+      "requires": {
+        "typescript": "*"
+      }
     },
     "typescript": {
       "version": "4.6.4",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "numcore": "https://github.com/tompng/numcore.git"
+    "numcore": "../numcore"
   },
   "devDependencies": {
     "typescript": "*"

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -379,19 +379,71 @@ export function renderParametric(
   const yOffset = offset - size * range.yMin / (range.yMax - range.yMin)
   const ctx = canvas.getContext('2d')!
   ctx.save()
-  ctx.beginPath()
   const N = 512
-  ctx.rect(0, 0, size, size)
-  ctx.clip()
   ctx.globalAlpha = 1
   ctx.strokeStyle = renderMode.color
   ctx.lineWidth = renderMode.lineWidth
   ctx.beginPath()
   const [tBegin, tEnd] = tRange
-  ctx.moveTo(xOffset + xFactor * formula.x(tBegin), yOffset + yFactor * formula.y(tBegin))
-  for (let i = 1; i <= N; i++) {
-    const t = tBegin + i / N * (tEnd - tBegin)
-    ctx.lineTo(xOffset + xFactor * formula.x(t), yOffset + yFactor * formula.y(t))
+  type Segment = [t0: number, t1: number, state: 0 | 1]
+  let segments: Segment[] = []
+  for (let i = 0; i < N; i++) segments.push([tBegin + (tEnd - tBegin) * i / N, tBegin + (tEnd - tBegin) * (i + 1) / N, 0])
+  const { xValueFunc, yValueFunc, xRangeFunc, yRangeFunc } = formula
+  const { EQNAN } = RangeResults
+  const xAreaMin = -xOffset / xFactor
+  const xAreaMax = (size - xOffset) / xFactor
+  const yAreaMin = -yOffset / yFactor
+  const yAreaMax = (size - yOffset) / yFactor
+  const drawSegments: [number, number][] = []
+  for (let level = 0; level < 16 && drawSegments.length < 65536 && segments.length < 65536; level++) {
+    const nextSegments: Segment[] = []
+    for (const [t0, t1] of segments) {
+      const xResult = xRangeFunc(t0, t1)
+      const yResult = yRangeFunc(t0, t1)
+      if (xResult === EQNAN || yResult === EQNAN) continue
+      const [xStat, xMin, xMax] = xResult
+      const [yStat, yMin, yMax] = yResult
+      const tc = (t0 + t1) / 2
+      if (xStat < 0 || yStat < 0) {
+        nextSegments.push([t0, tc, 0], [tc, t1, 0])
+      } else if (xAreaMin <= xMax && xMin <= xAreaMax && yAreaMin <= yMax && yMin <= yAreaMax) {
+        if (xAreaMin <= xMin && xMax <= xAreaMax && yAreaMin <= yMin && yMax <= yAreaMax) {
+          drawSegments.push([t0, t1])
+        } else {
+          nextSegments.push([t0, tc, 1], [tc, t1, 1])
+        }
+      }
+    }
+    segments = nextSegments
+  }
+  for (const [t0, t1, stat] of segments) if (stat) drawSegments.push([t0, t1])
+  for (const [t0, t1] of drawSegments) {
+    const tc = (t0 + t1) / 2
+    const x0 = xOffset + xFactor * xValueFunc(t0)
+    const y0 = yOffset + yFactor * yValueFunc(t0)
+    const xc = xOffset + xFactor * xValueFunc(tc)
+    const yc = yOffset + yFactor * yValueFunc(tc)
+    const x1 = xOffset + xFactor * xValueFunc(t1)
+    const y1 = yOffset + yFactor * yValueFunc(t1)
+    const l0 = (x0 - xc) ** 2 + (y0 - yc) ** 2
+    const l1 = (x1 - xc) ** 2 + (y1 - yc) ** 2
+    const l = Math.sqrt(Math.max(l0, l1))
+    const n = Math.min(Math.ceil(2 * l / 4), 32)
+    if (n <= 2) {
+      ctx.moveTo(x0, y0)
+      ctx.lineTo(xc, yc)
+      ctx.lineTo(x1, y1)
+    } else {
+      let x = x0
+      let y = y0
+      ctx.moveTo(x, y)
+      for (let i = 1; i <= n; i++) {
+        const t = t0 + (t1 - t0) * i / n
+        x = xOffset + xFactor * xValueFunc(t)
+        y = yOffset + yFactor * yValueFunc(t)
+        ctx.lineTo(x, y)
+      }
+    }
   }
   ctx.stroke()
   ctx.restore()

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -3,6 +3,7 @@ import {
   FillMode,
   ParsedEquation1D,
   ParsedEquation2D,
+  ParsedParametric,
 } from './parser'
 
 function fillModeToMask(fillMode: FillMode) {
@@ -356,5 +357,74 @@ export function render1D(
       }
     }
   }
+  ctx.restore()
+}
+
+export function renderParametric(
+  canvas: HTMLCanvasElement,
+  size: number,
+  offset: number,
+  range: RenderingRange,
+  tRange: [number, number],
+  formula: ParsedParametric,
+  renderMode: {
+    color: string
+    lineWidth: number
+    fillAlpha: number
+  }
+) {
+  const xFactor = size / (range.xMax - range.xMin)
+  const xOffset = offset - size * range.xMin / (range.xMax - range.xMin)
+  const yFactor = size / (range.yMax - range.yMin)
+  const yOffset = offset - size * range.yMin / (range.yMax - range.yMin)
+  const ctx = canvas.getContext('2d')!
+  ctx.save()
+  ctx.beginPath()
+  const N = 512
+  ctx.rect(0, 0, size, size)
+  ctx.clip()
+  ctx.globalAlpha = 1
+  ctx.strokeStyle = renderMode.color
+  ctx.lineWidth = renderMode.lineWidth
+  ctx.beginPath()
+  const [tBegin, tEnd] = tRange
+  ctx.moveTo(xOffset + xFactor * formula.x(tBegin), yOffset + yFactor * formula.y(tBegin))
+  for (let i = 1; i <= N; i++) {
+    const t = tBegin + i / N * (tEnd - tBegin)
+    ctx.lineTo(xOffset + xFactor * formula.x(t), yOffset + yFactor * formula.y(t))
+  }
+  ctx.stroke()
+  ctx.restore()
+}
+
+export function renderPoint(
+  canvas: HTMLCanvasElement,
+  size: number,
+  offset: number,
+  range: RenderingRange,
+  point: { x: number; y: number },
+  renderMode: {
+    color: string
+    lineWidth: number
+    fillAlpha: number
+  }
+) {
+  const xFactor = size / (range.xMax - range.xMin)
+  const xOffset = offset - size * range.xMin / (range.xMax - range.xMin)
+  const yFactor = size / (range.yMax - range.yMin)
+  const yOffset = offset - size * range.yMin / (range.yMax - range.yMin)
+  const ctx = canvas.getContext('2d')!
+  ctx.save()
+  ctx.beginPath()
+  ctx.rect(0, 0, size, size)
+  ctx.clip()
+  ctx.fillStyle = ctx.strokeStyle = renderMode.color
+  ctx.globalAlpha = renderMode.fillAlpha
+  ctx.beginPath()
+  ctx.arc(xOffset + xFactor * point.x, yOffset + yFactor * point.y, renderMode.lineWidth * 2, 0, 2 * Math.PI)
+  ctx.fill()
+  ctx.globalAlpha = 1
+  ctx.lineWidth = renderMode.lineWidth
+  ctx.stroke()
   ctx.restore()
 }

--- a/src/view.ts
+++ b/src/view.ts
@@ -335,6 +335,7 @@ export class View {
           const right = Math.round(width / 2 + (panel.dx * (panel.ix + 1) - center.x) / sizePerPixel.x)
           const bottom = Math.round(height / 2 + (panel.dy * panel.iy - center.y) / sizePerPixel.y)
           const top = Math.round(height / 2 + (panel.dy * (panel.iy + 1) - center.y) / sizePerPixel.y)
+          const t = performance.now()
           ctx.drawImage(
             image,
             left - offsetX * (right - left) / panelSize,
@@ -342,6 +343,16 @@ export class View {
             (right - left) * image.width / panelSize,
             (top - bottom) * image.height / panelSize
           )
+          if (performance.now() - t > 1000) {
+            console.log(`DRAW ${image.width}x${image.height} ${performance.now() - t}`)
+            ;(window as any).errorImage = image
+            console.log(
+              left - offsetX * (right - left) / panelSize,
+              bottom - height - offsetY * (top - bottom) / panelSize,
+              (right - left) * image.width / panelSize,
+              (top - bottom) * image.height / panelSize
+            )
+          }
         }
       }
       ctx.restore()


### PR DESCRIPTION
numcoreのpoint branchが必要
- `(1,2)` `(3, f(3))` などの点の描画
- `(cost, sint)` など媒介変数曲線の描画
  - `(t, tant)` が正しく途切れる
  - `(t, tsin(9logt))` がかなり拡大できる

TODO: package.json元に戻しておく